### PR TITLE
Add release-workflow & Scaladex badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ### content-api-client-aws
 _A library for helping with requests to an IAM-authorised AWS api-gateway_
 
+[![content-api-client-aws Scala version support](https://index.scala-lang.org/guardian/content-api-client-aws/content-api-client-aws/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/content-api-client-aws/content-api-client-aws)
 [![Release](https://github.com/guardian/content-api-client-aws/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/content-api-client-aws/actions/workflows/release.yml)
 
 Creates the necessary authorisation headers based on a request.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ### content-api-client-aws
-A library for helping with requests to an IAM-authorised AWS api-gateway.
+_A library for helping with requests to an IAM-authorised AWS api-gateway_
+
+[![Release](https://github.com/guardian/content-api-client-aws/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/content-api-client-aws/actions/workflows/release.yml)
 
 Creates the necessary authorisation headers based on a request.
 E.g.
-```
+```scala
 import com.gu.contentapi.client.{IAMSigner, IAMEncoder}
 
 val signer = new IAMSigner(credentialsProvider, awsRegion))


### PR DESCRIPTION
The release badge looks like this: 

![image](https://github.com/guardian/content-api-client-aws/assets/52038/dcf8d919-2c39-4096-bf5e-d003eebec6f0)

...and links directly to the Release workflow, useful for getting there to make a new release!