### PR TITLE
bump AWS library to version 1.12.770

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ releaseProcess := Seq[ReleaseStep](
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.12.638",
+  "com.amazonaws" % "aws-java-sdk-core" % "1.12.770",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
 )


### PR DESCRIPTION
in order to fix security vulnerability in transitive dependency

https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538

as this is just a minor version update the bump was pretty much automatic.

The library is used in a number of places but rather than test them test them all I think the individual consumers of the library should integrate the new version of this library and make sure their app still works.