### PR TITLE
Migrate to AWS SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates the necessary authorisation headers based on a request.
 E.g.
 
 ```scala
-import com.gu.contentapi.client.IAMEncoder
+import com.gu.contentapi.client.{IAMEncoder, IAMSigner}
 
 val signer = new IAMSigner(credentialsProvider, awsRegion)
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ _A library for helping with requests to an IAM-authorised AWS api-gateway_
 
 Creates the necessary authorisation headers based on a request.
 E.g.
-```scala
-import com.gu.contentapi.client.{IAMSigner, IAMEncoder}
 
-val signer = new IAMSigner(credentialsProvider, awsRegion))
+```scala
+import com.gu.contentapi.client.IAMEncoder
+
+val signer = new IAMSigner(credentialsProvider, awsRegion)
 
 //Query params must be encoded correctly
 val queryString = IAMEncoder.encodeParams("testparam=with spaces")
 
 val uri = URI.create(s"$endpoint/$path?$queryString")
 
-val headers: Map[String,String] = signer.addIAMHeaders(Map.empty[String,String], uri)
+val headers: Map[String, String] = signer.addIAMHeaders(Map.empty[String, String], uri)
 
 //...create a request with uri and headers
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ releaseProcess := Seq[ReleaseStep](
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.12.770",
   "org.scalatest" %% "scalatest" % "3.0.9" % Test,
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0"
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0",
+  "software.amazon.awssdk" % "auth" % "2.35.3",
 )

--- a/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
+++ b/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
@@ -1,26 +1,23 @@
 package com.gu.contentapi.client
 
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.http.{SdkHttpFullRequest, SdkHttpMethod}
+import software.amazon.awssdk.http.auth.aws.signer.{AwsV4HttpSigner, AwsV4FamilyHttpSigner}
+import software.amazon.awssdk.http.auth.spi.signer.SignRequest
+import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity
+
 import java.net.URI
-
-import com.amazonaws.DefaultRequest
-import com.amazonaws.auth.{AWS4Signer, AWSCredentialsProvider}
-import com.amazonaws.http.HttpMethodName
-
 import scala.jdk.CollectionConverters._
 
 /**
   * For api-gateway authorization.
   */
-class IAMSigner(credentialsProvider: AWSCredentialsProvider, awsRegion: String) {
+class IAMSigner(credentialsProvider: AwsCredentialsProvider, awsRegion: String) {
 
   private val serviceName = "execute-api"
+  private val signer = AwsV4HttpSigner.create()
 
-  private val signer = {
-    val sig = new AWS4Signer()
-    sig.setRegionName(awsRegion)
-    sig.setServiceName(serviceName)
-    sig
-  }
+  val credentials = credentialsProvider.resolveCredentials()
 
   /**
     * Returns the given set of headers, updated to include AWS sig4v signed headers based on the request and the credentials
@@ -30,31 +27,43 @@ class IAMSigner(credentialsProvider: AWSCredentialsProvider, awsRegion: String) 
     * @return         Updated set of headers, including the authorisation headers
     */
   def addIAMHeaders(headers: Map[String, String], uri: URI): Map[String, String] = {
-    val requestToSign = {
-      val req = new DefaultRequest(serviceName)
 
+    val queryParams: Map[String, java.util.List[String]] =
+      Option(uri.getQuery)
+        .map(_.split("&").toList.flatMap { s =>
+          s.split("=").toList match {
+            case k :: v :: Nil => Some(k -> java.util.Collections.singletonList(v))
+            case _ => None
+          }
+        }.toMap)
+        .getOrElse(Map.empty)
+
+    val unsignedRequest: SdkHttpFullRequest = {
       //api-gateway will break the compressed json response if we don't supply an accept header
       val headersWithAccept =
         if (headers.contains("accept") || headers.contains("Accept")) headers
         else headers + ("accept" -> "application/json")
 
-      req.setHeaders(headersWithAccept.asJava)
-      req.setEndpoint(new java.net.URI(s"${uri.getScheme}://${uri.getHost}"))
-      req.setHttpMethod(HttpMethodName.GET)
-      req.setResourcePath(uri.getPath)
+      val reqBuilder = SdkHttpFullRequest.builder()
+        .method(SdkHttpMethod.GET)
+        .uri(new java.net.URI(s"${uri.getScheme}://${uri.getHost}"))
+        .encodedPath(uri.getPath)
 
-      if (uri.getQuery != null) {
-        req.setParameters(uri.getQuery.split("&").toList.flatMap { s =>
-          s.split("=").toList match {
-            case k :: (v :: Nil) => Some(k -> List(v).asJava)
-            case _ => None
-          }
-        }.toMap.asJava)
-      }
-      req
+      headersWithAccept.foreach { case (k, v) => reqBuilder.putHeader(k, v) }
+      queryParams.foreach { case (k, v) => reqBuilder.putRawQueryParameter(k, v) }
+
+      reqBuilder.build()
     }
 
-    signer.sign(requestToSign, credentialsProvider.getCredentials)
-    requestToSign.getHeaders.asScala.toMap
+    val signedRequest = signer.sign { r: SignRequest.Builder[AwsCredentialsIdentity] =>
+      r.identity(credentials)
+        .request(unsignedRequest)
+        .putProperty(AwsV4HttpSigner.REGION_NAME, awsRegion)
+        .putProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME, serviceName)
+    }
+
+    signedRequest.request().headers().asScala.view
+      .mapValues(_.asScala.headOption.getOrElse(""))
+      .toMap
   }
 }

--- a/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
+++ b/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
@@ -62,8 +62,8 @@ class IAMSigner(credentialsProvider: AwsCredentialsProvider, awsRegion: String) 
         .putProperty(AwsV4FamilyHttpSigner.SERVICE_SIGNING_NAME, serviceName)
     }
 
-    signedRequest.request().headers().asScala.view
-      .mapValues(_.asScala.headOption.getOrElse(""))
+    signedRequest.request().headers().asScala
+      .map { case (k, v) => k -> v.asScala.headOption.getOrElse("") }
       .toMap
   }
 }

--- a/src/test/scala/com/gu/contentapi/client/IAMSignerSpec.scala
+++ b/src/test/scala/com/gu/contentapi/client/IAMSignerSpec.scala
@@ -1,0 +1,25 @@
+package com.gu.contentapi.client
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class IAMSignerSpec extends FlatSpec with Matchers {
+
+  val credentials = AwsBasicCredentials.create("test-access-key", "test-secret-key")
+  val credentialsProvider: AwsCredentialsProvider = StaticCredentialsProvider.create(credentials)
+  val uri = new java.net.URI("https://example.com/test/path?a=b%20c&1=2%2C3")
+
+  val signer = new IAMSigner(credentialsProvider, "eu-west-1")
+
+  it should "return a map of IAM signed headers" in {
+    val headers = Map(
+      "a" -> "test-a",
+      "1" -> "test-2",
+    )
+    val r = signer.addIAMHeaders(headers, uri)
+    r.get("Authorization").getOrElse("").contains("SignedHeaders=1;a;accept;host;x") shouldBe true
+  }
+}
+


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrades the `IAMSigner` class to use AWS sdk v2 plus adds a simple unit test. 

Address https://github.com/guardian/content-api-client-aws/issues/12
This library is being used in a [number of repos](https://github.com/search?q=org%3Aguardian+%22content-api-client-aws%22+NOT+repo%3Aguardian%2Fcontent-api-client-aws+NOT+repo%3Aguardian%2Fscala-guild-administration+NOT+repo%3Aguardian%2Fgithub-secret-access&type=code)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
