### PR TITLE
Add setup-scala for the sbt-dependency-graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1


### PR DESCRIPTION
This workflow is currently failing due to the  old problem of the change in Ubuntu not having sbt installed by default (https://github.com/actions/runner-images/issues/9369 , etc).
