### PR TITLE
Fix Compatibility-Checking for this Single-Module Project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ Test / testOptions +=
   Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
 
 releaseCrossBuild := true
-releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
+releaseVersion := ReleaseVersion.fromAssessedCompatibilityWithLatestRelease().value
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,


### PR DESCRIPTION
Fix this (annoying!) issue for this repo:

* https://github.com/guardian/gha-scala-library-release-workflow/issues/81

...as @vlbee pointed out, the release process only treated #13 as a 'point' release when she did a preview release of that PR.

So long as _this_ PR is merged before the next full release, the release will make a major-version bump.