### PR TITLE
allow repeated calling of `resolveCredentials` to get fresh session credentials

### DIFF
--- a/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
+++ b/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
@@ -17,7 +17,7 @@ class IAMSigner(credentialsProvider: AwsCredentialsProvider, awsRegion: String) 
   private val serviceName = "execute-api"
   private val signer = AwsV4HttpSigner.create()
 
-  val credentials = credentialsProvider.resolveCredentials()
+  def credentials = credentialsProvider.resolveCredentials()
 
   /**
     * Returns the given set of headers, updated to include AWS sig4v signed headers based on the request and the credentials


### PR DESCRIPTION
Followup to #14, which updates the `resolveCredentials` call to be part of a function (ie. a `def` declaration), so that updated credentials are fetched on subsequent signings.

With a `val`, credentials are fetched when the class is constructed, but they will only be valid for a short time before expiring, and fresh credentials should be fetched, eg. by default, AssumeRole credentials are valid for 1 hour.

It looks like the SDK providers include some caching behaviour to avoid too many credentials request under higher load, eg. https://github.com/aws/aws-sdk-java-v2/blob/85f098a0232a7cabf6a75986c9e638216765bcc6/services/sts/src/main/java/software/amazon/awssdk/services/sts/auth/StsCredentialsProvider.java#L106

Tested in https://github.com/guardian/crosswordv2/pull/662